### PR TITLE
fixed deprecation error in jade layout.

### DIFF
--- a/views/layout.jade
+++ b/views/layout.jade
@@ -1,4 +1,4 @@
-doctype 5
+doctype html
 html
 	head
 		title= title


### PR DESCRIPTION
Error: /12devsNodeJsDraw/views/layout.jade:1

> 1| doctype 5
>     2| html
>     3|  head
>     4|      title= title

`doctype 5` is deprecated, you must now use `doctype html`
